### PR TITLE
Avoid closing System#out

### DIFF
--- a/common/src/main/java/com/fox2code/foxloader/launcher/LoggerHelper.java
+++ b/common/src/main/java/com/fox2code/foxloader/launcher/LoggerHelper.java
@@ -209,9 +209,13 @@ final class LoggerHelper {
 
     private static class SystemOutConsoleHandler extends ConsoleHandler {
         SystemOutConsoleHandler() {
-            setOutputStream(System.out);
             setFormatter(new FoxLoaderConsoleLogFormatter());
             setLevel(Level.ALL);
+        }
+
+        @Override
+        protected synchronized void setOutputStream(OutputStream out) throws SecurityException {
+        	super.setOutputStream(System.out);
         }
     }
 


### PR DESCRIPTION
As mentioned [here](https://stackoverflow.com/a/194198), using `setOutputStream` will close the previous stream, which for `ConsoleHandler` will be `System#out`. Some JVMs will ignore doing this, whilst others can spam `Stream closed`, so it's better to do it this way

