### PR TITLE
Client: Entity Renderer Registry Method

### DIFF
--- a/client/src/main/java/com/fox2code/foxloader/client/mixins/MixinRenderManager.java
+++ b/client/src/main/java/com/fox2code/foxloader/client/mixins/MixinRenderManager.java
@@ -1,0 +1,36 @@
+package com.fox2code.foxloader.client.mixins;
+
+import com.fox2code.foxloader.loader.ClientMod;
+import com.fox2code.foxloader.loader.Mod;
+import com.fox2code.foxloader.loader.ModContainer;
+import com.fox2code.foxloader.loader.ModLoader;
+import net.minecraft.src.client.renderer.entity.Render;
+import net.minecraft.src.client.renderer.entity.RenderManager;
+import net.minecraft.src.game.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.*;
+
+@Mixin(RenderManager.class)
+public class MixinRenderManager {
+	@Shadow private Map<Class<?>, Render> entityRenderMap;
+
+	@Inject(method = "<init>", at = @At(value = "INVOKE", ordinal = 45, shift = At.Shift.AFTER,
+			target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+	private void onInitLastPut(CallbackInfo ci) {
+		Map<Class<? extends Entity>, Render> renderMap = new HashMap<>();
+
+		for (ModContainer container : ModLoader.getModContainers()) {
+			Mod clientMod = container.getClientMod();
+			if (clientMod instanceof ClientMod) {
+				((ClientMod) clientMod).registerRenderers(renderMap);
+			}
+		}
+
+		entityRenderMap.putAll(renderMap);
+	}
+}

--- a/client/src/main/java/com/fox2code/foxloader/loader/ClientMod.java
+++ b/client/src/main/java/com/fox2code/foxloader/loader/ClientMod.java
@@ -3,9 +3,22 @@ package com.fox2code.foxloader.loader;
 import com.fox2code.foxloader.network.NetworkPlayer;
 import com.fox2code.foxloader.registry.RegisteredItemStack;
 import net.minecraft.client.Minecraft;
+import net.minecraft.src.client.renderer.entity.Render;
+import net.minecraft.src.game.entity.Entity;
 import net.minecraft.src.game.item.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Map;
 
 public interface ClientMod extends Mod.SidedMod {
+    /**
+     * Override to implement {@link Render renderers} for your {@link Entity entities}.
+     * @param renderers the list of renderers to modify
+     */
+    @ApiStatus.OverrideOnly
+    default void registerRenderers(Map<Class<? extends Entity>, Render> renderers) {
+    }
+
     static Minecraft getGameInstance() {
         return Minecraft.getInstance();
     }
@@ -22,6 +35,4 @@ public interface ClientMod extends Mod.SidedMod {
     static RegisteredItemStack toRegisteredItemStack(ItemStack registeredItemStack) {
         return (RegisteredItemStack) (Object) registeredItemStack;
     }
-
-
 }

--- a/client/src/main/resources/foxloader.client.mixins.json
+++ b/client/src/main/resources/foxloader.client.mixins.json
@@ -43,6 +43,7 @@
     "MixinPlayerControllerTest",
     "MixinRenderEngine",
     "MixinRenderItem",
+    "MixinRenderManager",
     "MixinStringTranslate",
     "MixinTextureMap",
     "MixinTexturePackCustom",


### PR DESCRIPTION
To use: The client mod *must* extend Mod and implement ClientMod. Override this new method and mutate the provided map.

```java
public final class MyModClient extends Mod implements ClientMod {
	@Override
	public void registerRenderers(Map<Class<? extends Entity>, Render> renderers) {
		renderers.put(MyEntity.class, new MyEntityRenderer());
	}
}
```

This is pretty much identical to the way ModLoader did it.
