### PR TITLE
Entity Type Registry

### DIFF
--- a/client/src/main/java/com/fox2code/foxloader/client/mixins/AccessorEntityList.java
+++ b/client/src/main/java/com/fox2code/foxloader/client/mixins/AccessorEntityList.java
@@ -1,0 +1,13 @@
+package com.fox2code.foxloader.client.mixins;
+
+import net.minecraft.src.game.entity.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.gen.*;
+
+@Mixin(EntityList.class)
+public interface AccessorEntityList {
+	@Invoker
+	static void invokeAddMapping(Class<?> entityClass, String entityTypeName, int entityTypeID) {
+		throw new IllegalStateException();
+	}
+}

--- a/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
+++ b/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
@@ -34,6 +34,11 @@ public class GameRegistryClient extends GameRegistry {
     public static final short[] blockIdMappingIn = new short[MAXIMUM_BLOCK_ID];
     public static final short[] blockIdMappingOut = new short[MAXIMUM_BLOCK_ID];
     public static final String[] itemIdMappingInNames = new String[MAXIMUM_ITEM_ID];
+
+    public static final int[] entityTypeIdMappingIn = new int[MAXIMUM_ENTITY_TYPE_ID];
+    public static final int[] entityTypeIdMappingOut = new int[MAXIMUM_ENTITY_TYPE_ID];
+    public static final String[] entityTypeIdMappingNames = new String[MAXIMUM_ENTITY_TYPE_ID];
+
     private static MappingState idMappingState = MappingState.CLIENT;
     private enum MappingState {
         CLIENT, SERVER, CUSTOM
@@ -129,13 +134,17 @@ public class GameRegistryClient extends GameRegistry {
         if (registryEntries.containsKey(name)) {
             throw new RuntimeException("Duplicate item/block string id: " + name);
         }
+
         if (fallbackId < 0 || fallbackId > 255) {
             throw new IllegalArgumentException("Invalid fallback id: " + fallbackId);
         }
+
         int itemId = nextItemId++;
+
         if (itemId > MAXIMUM_ITEM_ID) {
             throw new RuntimeException("Maximum block count registered! (Too many mods?)");
         }
+
         registryEntries.put(name, new RegistryEntry((short) itemId, (short) fallbackId, name,
                 StringTranslate.getInstance().translateKey("item." + name.replace(':', '.'))));
         return itemId;
@@ -147,10 +156,15 @@ public class GameRegistryClient extends GameRegistry {
             throw new RuntimeException("Duplicate entity string id: " + name);
         }
 
+        if (fallbackId < 0 || fallbackId > 202) {
+            throw new IllegalArgumentException("Invalid fallback id: " + fallbackId);
+        }
+
         int entityTypeId = nextEntityTypeId++;
 
-        if (entityTypeId > MAXIMUM_ITEM_ID) {
-            throw new RuntimeException("Maximum block count registered! (Too many mods?)");
+        if (entityTypeId > MAXIMUM_ENTITY_TYPE_ID) {
+            // This is extremely unlikely
+            throw new RuntimeException("Maximum entity type count registered! (Too many mods?)");
         }
 
         entityTypeEntries.put(name, new EntityTypeRegistryEntry(entityTypeId, fallbackId, name));
@@ -399,11 +413,11 @@ public class GameRegistryClient extends GameRegistry {
                 itemIdMappingIn[i] = DEFAULT_FALLBACK_BLOCK_ID;
                 itemIdMappingOut[i] = DEFAULT_FALLBACK_BLOCK_ID;
             }
-            for (int i = INITIAL_BLOCK_ID; i < MAXIMUM_BLOCK_ID; i++) {
+            for (short i = INITIAL_BLOCK_ID; i < MAXIMUM_BLOCK_ID; i++) {
                 blockIdMappingIn[i] = DEFAULT_FALLBACK_BLOCK_ID;
                 blockIdMappingOut[i] = DEFAULT_FALLBACK_BLOCK_ID;
             }
-            for (int i = INITIAL_ITEM_ID; i < MAXIMUM_ITEM_ID; i++) {
+            for (short i = INITIAL_ITEM_ID; i < MAXIMUM_ITEM_ID; i++) {
                 itemIdMappingIn[i] = DEFAULT_FALLBACK_ITEM_ID;
                 itemIdMappingOut[i] = DEFAULT_FALLBACK_ITEM_ID;
             }
@@ -423,35 +437,46 @@ public class GameRegistryClient extends GameRegistry {
             return;
         }
         idMappingState = MappingState.CUSTOM;
-        for (RegistryEntry registryEntry : serverHello.registryEntries.values()) {
-            final short remoteId = registryEntry.realId;
+        for (RegistryEntry entry : serverHello.registryEntries.values()) {
+            final short remoteId = entry.realId;
             if (isLoaderReservedItemId(remoteId)) {
-                RegistryEntry local = registryEntries.get(
-                        itemIdMappingInNames[remoteId] = registryEntry.name);
+                RegistryEntry local = registryEntries.get(itemIdMappingInNames[remoteId] = entry.name);
                 if (local == null) {
-                    itemIdMappingIn[remoteId] = registryEntry.fallbackId;
+                    itemIdMappingIn[remoteId] = entry.fallbackId;
                     if (remoteId >= INITIAL_TRANSLATED_BLOCK_ID &&
                             remoteId < MAXIMUM_TRANSLATED_BLOCK_ID) {
-                        blockIdMappingIn[convertItemIdToBlockId(remoteId)] = registryEntry.fallbackId;
+                        blockIdMappingIn[convertItemIdToBlockId(remoteId)] = entry.fallbackId;
                     }
                 } else {
                     itemIdMappingIn[remoteId] = local.realId;
                     itemIdMappingOut[local.realId] = remoteId;
-                    if (remoteId >= INITIAL_TRANSLATED_BLOCK_ID &&
-                            remoteId < MAXIMUM_TRANSLATED_BLOCK_ID) {
-                        if (local.realId >= INITIAL_TRANSLATED_BLOCK_ID &&
-                                local.realId < MAXIMUM_TRANSLATED_BLOCK_ID) {
+                    if (remoteId >= INITIAL_TRANSLATED_BLOCK_ID && remoteId < MAXIMUM_TRANSLATED_BLOCK_ID) {
+                        if (local.realId >= INITIAL_TRANSLATED_BLOCK_ID && local.realId < MAXIMUM_TRANSLATED_BLOCK_ID) {
                             final short remoteBlockId = (short) convertItemIdToBlockId(remoteId);
                             final short localBlockId = (short) convertItemIdToBlockId(local.realId);
                             blockIdMappingIn[remoteBlockId] = localBlockId;
                             blockIdMappingOut[localBlockId] = remoteBlockId;
                         } else {
                             // We should never reach here, but let still "support" this extreme case.
-                            blockIdMappingIn[convertItemIdToBlockId(remoteId)] = registryEntry.fallbackId;
+                            blockIdMappingIn[convertItemIdToBlockId(remoteId)] = entry.fallbackId;
                         }
                     }
                 }
             }
+        }
+
+        for (EntityTypeRegistryEntry entry : serverHello.entityTypeRegistryEntries.values()) {
+            final int remoteId = entry.realId;
+            if (isLoaderReservedEntityTypeId(remoteId)) {
+                EntityTypeRegistryEntry local = entityTypeEntries.get(entityTypeIdMappingNames[remoteId] = entry.name);
+                if (local == null) {
+                    entityTypeIdMappingIn[remoteId] = entry.fallbackId;
+                    continue;
+                }
+
+				entityTypeIdMappingIn[remoteId] = local.realId;
+                entityTypeIdMappingOut[local.realId] = remoteId;
+			}
         }
     }
 }

--- a/client/src/main/resources/foxloader.client.mixins.json
+++ b/client/src/main/resources/foxloader.client.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.fox2code.foxloader.client.mixins",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "AccessorEntityList",
     "MixinBlock",
     "MixinBlockFire",
     "MixinChunk",

--- a/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
+++ b/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
@@ -256,6 +256,13 @@ public abstract class Mod implements LifecycleListener {
     }
 
     /**
+     * @see GameRegistry#registerNewEntityType(String, Class, int)
+     */
+    public void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass) {
+        GameRegistry.getInstance().registerNewEntityType(name, entityClass);
+    }
+
+    /**
      * @see GameRegistry#registerRecipe(RegisteredItemStack, Object...)
      */
     public void registerRecipe(RegisteredItemStack result, Object... recipe) {

--- a/common/src/main/java/com/fox2code/foxloader/loader/packet/ServerHello.java
+++ b/common/src/main/java/com/fox2code/foxloader/loader/packet/ServerHello.java
@@ -1,5 +1,6 @@
 package com.fox2code.foxloader.loader.packet;
 
+import com.fox2code.foxloader.registry.EntityTypeRegistryEntry;
 import com.fox2code.foxloader.registry.RegistryEntry;
 
 import java.io.DataInputStream;
@@ -9,64 +10,92 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class ServerHello extends FoxPacket {
-    public static final int SERVER_HELLO_VERSION = 0;
+    public static final int SERVER_HELLO_VERSION = 1;
     private static final int SERVER_HELLO_VERSION_NEXT = 1;
 
     public HashMap<String, RegistryEntry> registryEntries;
     public HashMap<String, String> metadata;
+    public HashMap<String, EntityTypeRegistryEntry> entityTypeRegistryEntries;
 
     public ServerHello() {
         super(0, false);
     }
 
     public ServerHello(HashMap<String, RegistryEntry> registryEntries,
-                       HashMap<String, String> metadata) {
+                       HashMap<String, String> metadata,
+                       HashMap<String, EntityTypeRegistryEntry> entityTypeRegistryEntries) {
         super(0, false);
         this.registryEntries = registryEntries;
         this.metadata = metadata;
+        this.entityTypeRegistryEntries = entityTypeRegistryEntries;
     }
 
     @Override
-    public void readData(DataInputStream dataInputStream) throws IOException {
-        int serverHelloVersion = dataInputStream.readUnsignedShort();
+    public void readData(DataInputStream inStream) throws IOException {
+        int serverHelloVersion = inStream.readUnsignedShort();
         if (serverHelloVersion >= SERVER_HELLO_VERSION_NEXT &&
                 // Next field is how much backward compatible is the packet
-                dataInputStream.readUnsignedShort() > SERVER_HELLO_VERSION_NEXT) {
+                inStream.readUnsignedShort() > SERVER_HELLO_VERSION_NEXT) {
             throw new RuntimeException("Client is critically out of date, please update FoxLoader");
         }
-        int entries = dataInputStream.readUnsignedShort();
-        registryEntries = new HashMap<>(entries);
-        while (entries-->0) {
-            RegistryEntry registryEntry = new RegistryEntry(
-                    dataInputStream.readShort(), dataInputStream.readShort(),
-                    dataInputStream.readUTF(), dataInputStream.readUTF());
-            registryEntries.put(registryEntry.name, registryEntry);
+
+        int entries = inStream.readUnsignedShort();
+        this.registryEntries = new HashMap<>(entries);
+        while (entries-- > 0) {
+            RegistryEntry entry = new RegistryEntry(
+                    inStream.readShort(), inStream.readShort(),
+                    inStream.readUTF(), inStream.readUTF());
+            this.registryEntries.put(entry.name, entry);
         }
-        if (dataInputStream.available() == 0) {
+
+        if (inStream.available() < 2) {
+            // Too few bytes to read the next short.
+            this.metadata = new HashMap<>();
+        } else {
+            entries = inStream.readUnsignedShort();
             metadata = new HashMap<>();
-            return;
+            while (entries-- > 0) {
+                metadata.put(inStream.readUTF(), inStream.readUTF());
+            }
         }
-        entries = dataInputStream.readUnsignedShort();
-        metadata = new HashMap<>();
-        while (entries-->0) {
-            metadata.put(dataInputStream.readUTF(), dataInputStream.readUTF());
+
+        if (inStream.available() < 4) {
+            // Too few bytes to read the next integer.
+            this.entityTypeRegistryEntries = new HashMap<>();
+        } else {
+            int entityEntries = inStream.readInt();
+            entityTypeRegistryEntries = new HashMap<>(entityEntries);
+            while (entityEntries-- > 0) {
+                EntityTypeRegistryEntry entry = new EntityTypeRegistryEntry(
+                        inStream.readInt(), inStream.readInt(), inStream.readUTF());
+                this.entityTypeRegistryEntries.put(entry.name, entry);
+            }
         }
     }
 
     @Override
-    public void writeData(DataOutputStream dataOutputStream) throws IOException {
-        dataOutputStream.writeShort(SERVER_HELLO_VERSION);
-        dataOutputStream.writeShort(this.registryEntries.size());
+    public void writeData(DataOutputStream outStream) throws IOException {
+        outStream.writeShort(SERVER_HELLO_VERSION);
+
+        outStream.writeShort(this.registryEntries.size());
         for (RegistryEntry registryEntry : registryEntries.values()) {
-            dataOutputStream.writeShort(registryEntry.realId);
-            dataOutputStream.writeByte(registryEntry.fallbackId);
-            dataOutputStream.writeUTF(registryEntry.name);
-            dataOutputStream.writeUTF(registryEntry.fallbackDisplayName);
+            outStream.writeShort(registryEntry.realId);
+            outStream.writeByte(registryEntry.fallbackId);
+            outStream.writeUTF(registryEntry.name);
+            outStream.writeUTF(registryEntry.fallbackDisplayName);
         }
-        dataOutputStream.writeShort(this.metadata.size());
+
+        outStream.writeShort(this.metadata.size());
         for (Map.Entry<String, String> metadata : this.metadata.entrySet()) {
-            dataOutputStream.writeUTF(metadata.getKey());
-            dataOutputStream.writeUTF(metadata.getValue());
+            outStream.writeUTF(metadata.getKey());
+            outStream.writeUTF(metadata.getValue());
+        }
+
+        outStream.writeInt(this.entityTypeRegistryEntries.size());
+        for (EntityTypeRegistryEntry entry : entityTypeRegistryEntries.values()) {
+            outStream.writeInt(entry.realId);
+            outStream.writeInt(entry.fallbackId);
+            outStream.writeUTF(entry.name);
         }
     }
 }

--- a/common/src/main/java/com/fox2code/foxloader/registry/EntityTypeRegistryEntry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/EntityTypeRegistryEntry.java
@@ -1,10 +1,13 @@
 package com.fox2code.foxloader.registry;
 
+import org.jetbrains.annotations.ApiStatus;
+
 public class EntityTypeRegistryEntry {
 	public final int realId, fallbackId;
 	public final String name;
 
-	EntityTypeRegistryEntry(int realId, int fallbackId, String name) {
+	@ApiStatus.Internal
+	public EntityTypeRegistryEntry(int realId, int fallbackId, String name) {
 		this.realId = realId;
 		this.fallbackId = fallbackId;
 		this.name = name;

--- a/common/src/main/java/com/fox2code/foxloader/registry/EntityTypeRegistryEntry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/EntityTypeRegistryEntry.java
@@ -1,0 +1,12 @@
+package com.fox2code.foxloader.registry;
+
+public class EntityTypeRegistryEntry {
+	public final int realId, fallbackId;
+	public final String name;
+
+	EntityTypeRegistryEntry(int realId, int fallbackId, String name) {
+		this.realId = realId;
+		this.fallbackId = fallbackId;
+		this.name = name;
+	}
+}

--- a/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
@@ -16,8 +16,10 @@ public abstract class GameRegistry {
     public static final int INITIAL_BLOCK_ID = 360;
     public static final int MAXIMUM_BLOCK_ID = 1024; // Hard max: 1258
     public static final int INITIAL_ITEM_ID = 4096;
-    public static final int INITIAL_ENTITY_TYPE_ID = 210;
     public static final int MAXIMUM_ITEM_ID = 8192; // Hard max: 31999
+    public static final int INITIAL_ENTITY_TYPE_ID = 210;
+    // Array size limit is fuzzy so lets avoid it.
+    public static final int MAXIMUM_ENTITY_TYPE_ID = Integer.MAX_VALUE - Short.MAX_VALUE;
     // Block ids but translated to item ids
     public static final int INITIAL_TRANSLATED_BLOCK_ID = convertBlockIdToItemId(INITIAL_BLOCK_ID);
     public static final int MAXIMUM_TRANSLATED_BLOCK_ID = convertBlockIdToItemId(MAXIMUM_BLOCK_ID);
@@ -240,21 +242,27 @@ public abstract class GameRegistry {
 
     /**
      * @param itemId the item id
-     * @return if the id is reserved for mod loader use
+     * @return if the id is an item id reserved for mod loader use
      */
     public static boolean isLoaderReservedItemId(int itemId) {
-        return (itemId >= INITIAL_TRANSLATED_BLOCK_ID &&
-                itemId < MAXIMUM_TRANSLATED_BLOCK_ID) ||
-                (itemId >= INITIAL_ITEM_ID && itemId < MAXIMUM_ITEM_ID);
+        return (itemId >= INITIAL_TRANSLATED_BLOCK_ID && itemId < MAXIMUM_TRANSLATED_BLOCK_ID)
+                || (itemId >= INITIAL_ITEM_ID && itemId < MAXIMUM_ITEM_ID);
     }
 
     /**
      * @param itemId the item id
-     * @return if the id is reserved for mod loader and a block
+     * @return if the id is a block id reserved for mod loader use
      */
     public static boolean isLoaderReservedBlockItemId(int itemId) {
-        return (itemId >= INITIAL_TRANSLATED_BLOCK_ID &&
-                itemId < MAXIMUM_TRANSLATED_BLOCK_ID);
+        return itemId >= INITIAL_TRANSLATED_BLOCK_ID && itemId < MAXIMUM_TRANSLATED_BLOCK_ID;
+    }
+
+    /**
+     * @param entityTypeId the entity type id
+     * @return if the id is an entity id reserved for mod loader use
+     */
+    public static boolean isLoaderReservedEntityTypeId(int entityTypeId) {
+        return entityTypeId >= INITIAL_ENTITY_TYPE_ID && entityTypeId < MAXIMUM_ENTITY_TYPE_ID;
     }
 
     public interface Ingredient {}

--- a/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
@@ -8,6 +8,7 @@ import java.util.*;
 
 public abstract class GameRegistry {
     static final HashMap<String, RegistryEntry> registryEntries = new HashMap<>();
+    static final HashMap<String, EntityTypeRegistryEntry> entityTypeEntries = new HashMap<>();
     static final BlockBuilder DEFAULT_BLOCK_BUILDER = new BlockBuilder();
     static final ItemBuilder DEFAULT_ITEM_BUILDER = new ItemBuilder();
     private static GameRegistry gameRegistry;
@@ -15,6 +16,7 @@ public abstract class GameRegistry {
     public static final int INITIAL_BLOCK_ID = 360;
     public static final int MAXIMUM_BLOCK_ID = 1024; // Hard max: 1258
     public static final int INITIAL_ITEM_ID = 4096;
+    public static final int INITIAL_ENTITY_TYPE_ID = 210;
     public static final int MAXIMUM_ITEM_ID = 8192; // Hard max: 31999
     // Block ids but translated to item ids
     public static final int INITIAL_TRANSLATED_BLOCK_ID = convertBlockIdToItemId(INITIAL_BLOCK_ID);
@@ -23,6 +25,8 @@ public abstract class GameRegistry {
     public static final int DEFAULT_FALLBACK_BLOCK_ID = 1;
     // The default fallback id for items is planks.
     public static final int DEFAULT_FALLBACK_ITEM_ID = 5;
+    // The default fallback id for entity types is pig.
+    public static final int DEFAULT_FALLBACK_ENTITY_TYPE_ID = 90;
 
     public static GameRegistry getInstance() {
         return gameRegistry;
@@ -74,10 +78,17 @@ public abstract class GameRegistry {
     }
 
     /**
-     * @return list of registered modded entries
+     * @return list of registered modded block and item entries
      */
     public static Collection<RegistryEntry> getRegistryEntries() {
         return Collections.unmodifiableCollection(registryEntries.values());
+    }
+
+    /**
+     * @return list of registered modded entities
+     */
+    public static Collection<EntityTypeRegistryEntry> getEntityRegistryEntries() {
+        return Collections.unmodifiableCollection(entityTypeEntries.values());
     }
 
     /**
@@ -123,6 +134,11 @@ public abstract class GameRegistry {
     public abstract int generateNewItemId(String name, int fallbackId);
 
     /**
+     * Only use this if you know what you are doing.
+     */
+    public abstract int generateNewEntityTypeId(String name, int fallbackId);
+
+    /**
      * Register a new block into the game
      */
     public final RegisteredBlock registerNewBlock(String name, BlockBuilder blockBuilder) {
@@ -139,6 +155,15 @@ public abstract class GameRegistry {
     }
 
     public abstract RegisteredItem registerNewItem(String name, ItemBuilder itemBuilder, int fallbackId);
+
+	/**
+	 * Register a new entity type into the game
+	 */
+	public final void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass) {
+		this.registerNewEntityType(name, entityClass, DEFAULT_FALLBACK_ENTITY_TYPE_ID);
+	}
+
+	public abstract void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass, int fallbackId);
 
     protected static final String LATE_RECIPE_MESSAGE = "Too late to register recipes!";
     protected static boolean recipeFrozen = false;

--- a/common/src/main/java/com/fox2code/foxloader/registry/RegistryEntry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/RegistryEntry.java
@@ -1,9 +1,12 @@
 package com.fox2code.foxloader.registry;
 
+import org.jetbrains.annotations.ApiStatus;
+
 public final class RegistryEntry {
     public final short realId, fallbackId;
     public final String name, fallbackDisplayName;
 
+    @ApiStatus.Internal
     public RegistryEntry(short realId, short fallbackId, String name, String fallbackDisplayName) {
         this.realId = realId;
         this.fallbackId = fallbackId;

--- a/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
+++ b/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
@@ -42,21 +42,24 @@ public class GameRegistryServer extends GameRegistry {
 
     public static void freeze() {
         if (!ModLoader.areAllModsLoaded())
-            throw new IllegalArgumentException("Mods didn't finished to load!");
+            throw new IllegalArgumentException("Mods haven't finished loading!");
         // Compile server hello into a byte array for memory and performance efficiency.
         serverHello = ModLoader.Internal.compileServerHello(
-                new ServerHello(GameRegistry.registryEntries,
-                        new HashMap<>(SidedMetadataAPI.getSelfMetadata())));
-        final Block stoneBlock = Block.blocksList[0];
+                new ServerHello(
+                        GameRegistry.registryEntries,
+                        new HashMap<>(SidedMetadataAPI.getSelfMetadata()),
+                        GameRegistry.entityTypeEntries
+                ));
+        final Block airBlock = Block.blocksList[0]; // was named "stoneBlock" but that is incorrect
         for (int i = 0; i < Block.blocksList.length; i++) {
             if (Block.blocksList[i] == null) {
-                Block.blocksList[i] = stoneBlock;
+                Block.blocksList[i] = airBlock;
             }
         }
-        final Item stoneItem = Item.itemsList[0];
+        final Item airItem = Item.itemsList[0]; // was named "stoneItem" but that is incorrect
         for (int i = 0; i < Item.itemsList.length; i++) {
             if (Item.itemsList[i] == null) {
-                Item.itemsList[i] = stoneItem;
+                Item.itemsList[i] = airItem;
             }
         }
     }

--- a/server/src/main/java/com/fox2code/foxloader/server/mixins/AccessorEntityList.java
+++ b/server/src/main/java/com/fox2code/foxloader/server/mixins/AccessorEntityList.java
@@ -1,0 +1,13 @@
+package com.fox2code.foxloader.server.mixins;
+
+import net.minecraft.src.game.entity.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.gen.*;
+
+@Mixin(EntityList.class)
+public interface AccessorEntityList {
+	@Invoker
+	static void invokeAddMapping(Class<?> entityClass, String entityTypeName, int entityTypeID) {
+		throw new IllegalStateException();
+	}
+}

--- a/server/src/main/resources/foxloader.server.mixins.json
+++ b/server/src/main/resources/foxloader.server.mixins.json
@@ -5,6 +5,7 @@
   "plugin": "com.fox2code.foxloader.loader.mixin.MixinTestModePlugin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "AccessorEntityList",
     "MixinBlock",
     "MixinBlockFire",
     "MixinChunkBlockMap",


### PR DESCRIPTION
A simple invoker for `EntityList.addMapping` with an ID tracker separate from the block and item registry.

I think this should be moved to a separate registry class in future versions, with `GameRegistry` being renamed to `BlockAndItemRegistry` (or something like that). Maybe even separate those two into separate classes. Otherwise, it's bound to get extremely bloated.