### PR TITLE
`Mod` Mirrors of Register Recipe Functions

### DIFF
--- a/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
+++ b/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
@@ -11,8 +11,8 @@ import net.minecraft.src.client.gui.StringTranslate;
 import net.minecraft.src.game.block.*;
 import net.minecraft.src.game.item.*;
 import net.minecraft.src.game.recipe.*;
+import org.jetbrains.annotations.ApiStatus;
 
-import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -160,10 +160,7 @@ public class GameRegistryClient extends GameRegistry {
         int blockId = generateNewBlockId(name, fallbackId);
         Block block;
         Material material = MATERIAL.translate(blockBuilder.builtInMaterial);
-        String blockName = blockBuilder.blockName == null ? name : blockBuilder.blockName;
         Block blockSource = (Block) blockBuilder.blockSource;
-        String blockType = blockBuilder.blockType == null ?
-                (blockSource != null ? blockSource.getBlockName() : blockName) : blockBuilder.blockType;
         boolean selfNotify = false;
         switch (blockBuilder.getBuiltInBlockTypeForConstructor()) {
             default:
@@ -300,35 +297,37 @@ public class GameRegistryClient extends GameRegistry {
         return (RegisteredItem) item;
     }
 
-    private static boolean recipeFrozen = false;
-
     @Override
     public void registerRecipe(RegisteredItemStack result, Object... recipe) {
-        if (recipeFrozen) throw new IllegalArgumentException("Too late to register recipes!");
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         CraftingManager.getInstance().addRecipe(toItemStack(result), recipe);
     }
 
     @Override
     public void registerShapelessRecipe(RegisteredItemStack result, Ingredient... ingredients) {
-        if (recipeFrozen) throw new IllegalArgumentException("Too late to register recipes!");
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         CraftingManager.getInstance().addShapelessRecipe(toItemStack(result), (Object[]) ingredients);
     }
 
     @Override
-    public void addFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         FurnaceRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
     @Override
-    public void addBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         BlastFurnaceRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
     @Override
-    public void addFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         RefridgifreezerRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
+    @ApiStatus.Internal
     public static void freezeRecipes() {
         if (recipeFrozen) return;
         recipeFrozen = true;

--- a/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
+++ b/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
@@ -269,6 +269,27 @@ public abstract class Mod implements LifecycleListener {
         GameRegistry.getInstance().registerShapelessRecipe(result, ingredients);
     }
 
+    /**
+     * @see GameRegistry#registerFurnaceRecipe(RegisteredItem, RegisteredItemStack)
+     */
+    public void registerFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        GameRegistry.getInstance().registerFurnaceRecipe(input, output);
+    }
+
+    /**
+     * @see GameRegistry#registerBlastFurnaceRecipe(RegisteredItem, RegisteredItemStack)
+     */
+    public void registerBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        GameRegistry.getInstance().registerBlastFurnaceRecipe(input, output);
+    }
+
+    /**
+     * @see GameRegistry#registerFreezerRecipe(RegisteredItem, RegisteredItemStack)
+     */
+    public void registerFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+        GameRegistry.getInstance().registerFreezerRecipe(input, output);
+    }
+
     // For internal use only
     void loaderHandleServerHello(NetworkConnection networkConnection, ServerHello serverHello) {}
     void loaderHandleClientHello(NetworkConnection networkPlayer, ClientHello clientHello) {}

--- a/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
@@ -140,15 +140,42 @@ public abstract class GameRegistry {
 
     public abstract RegisteredItem registerNewItem(String name, ItemBuilder itemBuilder, int fallbackId);
 
+    protected static final String LATE_RECIPE_MESSAGE = "Too late to register recipes!";
+    protected static boolean recipeFrozen = false;
+
     public abstract void registerRecipe(RegisteredItemStack result, Object... recipe);
 
     public abstract void registerShapelessRecipe(RegisteredItemStack result, Ingredient... ingredients);
 
-    public abstract void addFurnaceRecipe(RegisteredItem input, RegisteredItemStack output);
+    public abstract void registerFurnaceRecipe(RegisteredItem input, RegisteredItemStack output);
 
-    public abstract void addBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output);
+    public abstract void registerBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output);
 
-    public abstract void addFreezerRecipe(RegisteredItem input, RegisteredItemStack output);
+    public abstract void registerFreezerRecipe(RegisteredItem input, RegisteredItemStack output);
+
+    /**
+     * @deprecated replace with {@link #registerFurnaceRecipe(RegisteredItem, RegisteredItemStack)}
+     */
+    @Deprecated
+    public void addFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        this.registerFurnaceRecipe(input, output);
+    }
+
+    /**
+     * @deprecated replace with {@link #registerBlastFurnaceRecipe(RegisteredItem, RegisteredItemStack)}
+     */
+    @Deprecated
+    public void addBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        this.registerBlastFurnaceRecipe(input, output);
+    }
+
+    /**
+     * @deprecated replace with {@link #registerFreezerRecipe(RegisteredItem, RegisteredItemStack)}
+     */
+    @Deprecated
+    public void addFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+        this.registerFreezerRecipe(input, output);
+    }
 
     @LuaInterop
     public boolean isFrozen() {

--- a/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
+++ b/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
@@ -14,8 +14,8 @@ import net.minecraft.src.game.item.ItemBlock;
 import net.minecraft.src.game.item.ItemBlockSlab;
 import net.minecraft.src.game.recipe.*;
 import net.minecraft.src.server.playergui.StringTranslate;
+import org.jetbrains.annotations.ApiStatus;
 
-import java.lang.reflect.Constructor;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Objects;
@@ -147,10 +147,7 @@ public class GameRegistryServer extends GameRegistry {
         int blockId = generateNewBlockId(name, fallbackId);
         Block block;
         Material material = MATERIAL.translate(blockBuilder.builtInMaterial);
-        String blockName = blockBuilder.blockName == null ? name : blockBuilder.blockName;
         Block blockSource = (Block) blockBuilder.blockSource;
-        String blockType = blockBuilder.blockType == null ?
-                (blockSource != null ? blockSource.getBlockName() : blockName) : blockBuilder.blockType;
         boolean selfNotify = false;
         switch (blockBuilder.getBuiltInBlockTypeForConstructor()) {
             default:
@@ -279,35 +276,37 @@ public class GameRegistryServer extends GameRegistry {
         return (RegisteredItem) item;
     }
 
-    private static boolean recipeFrozen = false;
-
     @Override
     public void registerRecipe(RegisteredItemStack result, Object... recipe) {
-        if (recipeFrozen) throw new IllegalArgumentException("Too late to register recipes!");
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         CraftingManager.getInstance().addRecipe(toItemStack(result), recipe);
     }
 
     @Override
     public void registerShapelessRecipe(RegisteredItemStack result, Ingredient... ingredients) {
-        if (recipeFrozen) throw new IllegalArgumentException("Too late to register recipes!");
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         CraftingManager.getInstance().addShapelessRecipe(toItemStack(result), (Object[]) ingredients);
     }
 
     @Override
-    public void addFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         FurnaceRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
     @Override
-    public void addBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerBlastFurnaceRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         BlastFurnaceRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
     @Override
-    public void addFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+    public void registerFreezerRecipe(RegisteredItem input, RegisteredItemStack output) {
+        if (recipeFrozen) throw new UnsupportedOperationException(LATE_RECIPE_MESSAGE);
         RefridgifreezerRecipes.instance.addSmelting(input.getRegisteredItemId(), toItemStack(output));
     }
 
+    @ApiStatus.Internal
     public static void freezeRecipes() {
         if (recipeFrozen) return;
         recipeFrozen = true;


### PR DESCRIPTION
Adds mirrors for `GameRegisty`'s registerRecipe methods in `Mod`.

Deprecates the `add*Recipe` methods to make them all match the `register*Recipe` naming convention. It also adds the "Too late to register recipes" exception to the rest of the recipe types.

This is a less serious pull request than my previous two. I'm not sure if you would approve of deprecating these old methods or adding exceptions (changing functionality slightly), but I think it's for the best.