### PR TITLE
Add registerTileEntityType

### DIFF
--- a/client/src/main/java/com/fox2code/foxloader/client/mixins/AccessorTileEntity.java
+++ b/client/src/main/java/com/fox2code/foxloader/client/mixins/AccessorTileEntity.java
@@ -1,0 +1,13 @@
+package com.fox2code.foxloader.client.mixins;
+
+import net.minecraft.src.game.block.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(TileEntity.class)
+public interface AccessorTileEntity {
+	@Invoker
+	static void invokeAddMapping(Class<?> entityClass, String entityTypeName) {
+		throw new IllegalStateException();
+	}
+}

--- a/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
+++ b/client/src/main/java/com/fox2code/foxloader/registry/GameRegistryClient.java
@@ -4,6 +4,7 @@ import static com.fox2code.foxloader.loader.ClientMod.*;
 
 import com.fox2code.foxloader.client.CreativeItems;
 import com.fox2code.foxloader.client.mixins.AccessorEntityList;
+import com.fox2code.foxloader.client.mixins.AccessorTileEntity;
 import com.fox2code.foxloader.client.registry.RegisteredBlockImpl;
 import com.fox2code.foxloader.loader.ModLoader;
 import com.fox2code.foxloader.loader.packet.ServerHello;
@@ -199,8 +200,6 @@ public class GameRegistryClient extends GameRegistry {
         Block blockSource = (Block) blockBuilder.blockSource;
         boolean selfNotify = false;
         switch (blockBuilder.getBuiltInBlockTypeForConstructor()) {
-            default:
-                throw new IllegalArgumentException("Invalid block type " + blockBuilder.builtInBlockType);
             case CUSTOM:
                 try {
                     block = (Block) blockBuilder.gameBlockProvider.provide(blockId, blockBuilder, ext);
@@ -241,6 +240,8 @@ public class GameRegistryClient extends GameRegistry {
                 block = new BlockStairs(blockId, Objects.requireNonNull(blockSource, "blockSource")) {};
                 selfNotify = true;
                 break;
+            default:
+                throw new IllegalArgumentException("Invalid block type " + blockBuilder.builtInBlockType);
         }
         if (selfNotify) {
             Block.selfNotify.set(blockId, true);
@@ -335,8 +336,15 @@ public class GameRegistryClient extends GameRegistry {
 
 	@Override
 	public void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass, int fallbackId) {
+        name = validateAndFixRegistryName(name);
 		AccessorEntityList.invokeAddMapping(entityClass, name, generateNewEntityTypeId(name, fallbackId));
 	}
+
+    @Override
+    public void registerNewTileEntityType(String name, Class<? extends RegisteredTileEntity> tileEntityClass) {
+        name = validateAndFixRegistryName(name);
+        AccessorTileEntity.invokeAddMapping(tileEntityClass, name);
+    }
 
     @Override
     public void registerRecipe(RegisteredItemStack result, Object... recipe) {

--- a/client/src/main/resources/foxloader.client.mixins.json
+++ b/client/src/main/resources/foxloader.client.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "AccessorEntityList",
+    "AccessorTileEntity",
     "AcessorSaveHandlers",
     "MixinChunkLoader",
     "MixinBlock",

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     api 'org.ow2.asm:asm-util:9.7'
     api 'org.ow2.asm:asm-commons:9.7'
     api 'org.semver4j:semver4j:5.3.0'
-    api 'net.fabricmc:sponge-mixin:0.15.0+mixin.0.8.7' // <- https://maven.fabricmc.net/net/fabricmc/sponge-mixin/
-    api 'io.github.llamalad7:mixinextras-common:0.4.0' // <- https://github.com/LlamaLad7/MixinExtras/releases
+    api 'net.fabricmc:sponge-mixin:0.15.5+mixin.0.8.7' // <- https://maven.fabricmc.net/net/fabricmc/sponge-mixin/
+    api 'io.github.llamalad7:mixinextras-common:0.4.1' // <- https://github.com/LlamaLad7/MixinExtras/releases
     api 'com.github.bawnorton.mixinsquared:mixinsquared-common:0.2.0-beta.6' // <- https://github.com/Bawnorton/MixinSquared/releases
     api 'it.unimi.dsi:fastutil-core:8.5.14'
 

--- a/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
+++ b/common/src/main/java/com/fox2code/foxloader/loader/Mod.java
@@ -256,10 +256,17 @@ public abstract class Mod implements LifecycleListener {
     }
 
     /**
-     * @see GameRegistry#registerNewEntityType(String, Class, int)
+     * @see GameRegistry#registerNewEntityType(String, Class)
      */
     public void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass) {
         GameRegistry.getInstance().registerNewEntityType(name, entityClass);
+    }
+
+    /**
+     * @see GameRegistry#registerNewTileEntityType(String, Class)
+     */
+    public void registerNewTileEntityType(String name, Class<? extends RegisteredTileEntity> entityClass) {
+        GameRegistry.getInstance().registerNewTileEntityType(name, entityClass);
     }
 
     /**

--- a/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
+++ b/common/src/main/java/com/fox2code/foxloader/registry/GameRegistry.java
@@ -18,7 +18,7 @@ public abstract class GameRegistry {
     public static final int INITIAL_ITEM_ID = 4096;
     public static final int MAXIMUM_ITEM_ID = 8192; // Hard max: 31999
     public static final int INITIAL_ENTITY_TYPE_ID = 210;
-    // Array size limit is fuzzy so lets avoid it.
+    // Array size limit is fuzzy so let's avoid it.
     public static final int MAXIMUM_ENTITY_TYPE_ID = 255; // Integer.MAX_VALUE - Short.MAX_VALUE;
     // Block ids but translated to item ids
     public static final int INITIAL_TRANSLATED_BLOCK_ID = convertBlockIdToItemId(INITIAL_BLOCK_ID);
@@ -165,7 +165,15 @@ public abstract class GameRegistry {
 		this.registerNewEntityType(name, entityClass, DEFAULT_FALLBACK_ENTITY_TYPE_ID);
 	}
 
+    /**
+     * Register a new entity type into the game
+     */
 	public abstract void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass, int fallbackId);
+
+    /**
+     * Register a new tile entity type into the game
+     */
+    public abstract void registerNewTileEntityType(String name, Class<? extends RegisteredTileEntity> tileEntityClass);
 
     protected static final String LATE_RECIPE_MESSAGE = "Too late to register recipes!";
     protected static boolean recipeFrozen = false;

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1024m -XX:-UseGCOverheadLimit -Dfile.encoding=UTF-8
 
 # FoxLoader properties
-foxloader.version=1.3.3
+foxloader.version=1.4.0
 foxloader.lastReIndevTransformerChanges=1.3.0
 # https://www.jitpack.io/#com.fox2code/FoxLoader
 

--- a/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
+++ b/server/src/main/java/com/fox2code/foxloader/registry/GameRegistryServer.java
@@ -5,6 +5,7 @@ import com.fox2code.foxloader.loader.ModLoader;
 import com.fox2code.foxloader.loader.packet.ServerHello;
 import com.fox2code.foxloader.network.SidedMetadataAPI;
 import com.fox2code.foxloader.server.mixins.AccessorEntityList;
+import com.fox2code.foxloader.server.mixins.AccessorTileEntity;
 import com.fox2code.foxloader.server.network.NetworkPlayerImpl;
 import com.fox2code.foxloader.server.registry.RegisteredBlockImpl;
 import net.minecraft.src.game.block.*;
@@ -167,8 +168,6 @@ public class GameRegistryServer extends GameRegistry {
         Block blockSource = (Block) blockBuilder.blockSource;
         boolean selfNotify = false;
         switch (blockBuilder.getBuiltInBlockTypeForConstructor()) {
-            default:
-                throw new IllegalArgumentException("Invalid block type " + blockBuilder.builtInBlockType);
             case CUSTOM:
                 try {
                     block = (Block) blockBuilder.gameBlockProvider.provide(blockId, blockBuilder, ext);
@@ -210,6 +209,8 @@ public class GameRegistryServer extends GameRegistry {
                 block = new BlockStairs(blockId, Objects.requireNonNull(blockSource, "blockSource")) {};
                 selfNotify = true;
                 break;
+            default:
+                throw new IllegalArgumentException("Invalid block type " + blockBuilder.builtInBlockType);
         }
         if (selfNotify) {
             Block.requiresSelfNotify[blockId] = true;
@@ -295,8 +296,15 @@ public class GameRegistryServer extends GameRegistry {
 
 	@Override
 	public void registerNewEntityType(String name, Class<? extends RegisteredEntity> entityClass, int fallbackId) {
+        name = validateAndFixRegistryName(name);
 		AccessorEntityList.invokeAddMapping(entityClass, name, generateNewEntityTypeId(name, fallbackId));
 	}
+
+    @Override
+    public void registerNewTileEntityType(String name, Class<? extends RegisteredTileEntity> tileEntityClass) {
+        name = validateAndFixRegistryName(name);
+        AccessorTileEntity.invokeAddMapping(tileEntityClass, name);
+    }
 
     @Override
     public void registerRecipe(RegisteredItemStack result, Object... recipe) {

--- a/server/src/main/java/com/fox2code/foxloader/server/mixins/AccessorTileEntity.java
+++ b/server/src/main/java/com/fox2code/foxloader/server/mixins/AccessorTileEntity.java
@@ -1,0 +1,13 @@
+package com.fox2code.foxloader.server.mixins;
+
+import net.minecraft.src.game.block.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(TileEntity.class)
+public interface AccessorTileEntity {
+	@Invoker
+	static void invokeAddMapping(Class<?> entityClass, String entityTypeName) {
+		throw new IllegalStateException();
+	}
+}

--- a/server/src/main/resources/foxloader.server.mixins.json
+++ b/server/src/main/resources/foxloader.server.mixins.json
@@ -6,6 +6,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "AccessorEntityList",
+    "AccessorTileEntity",
     "MixinBlock",
     "MixinBlockFire",
     "MixinChunkBlockMap",


### PR DESCRIPTION
- Adds methods to the `GameRegistry` and `Mod` classes to register `TileEntity` types (a simple accessor)
- Adds mod id prefix validation to entity type registry method (and the tile entity type registry method)
- Bumps the Fabric Mixin and MixinExtras dependencies to their latest versions at the time of commit
- Bumps FoxLoader's version to the next minor release (API changed, dependencies changed)