### PR TITLE
Fix BlockRenderManager using the wrong IDs

### DIFF
--- a/loader/src/main/java/com/fox2code/foxloader/client/BlockRenderManager.java
+++ b/loader/src/main/java/com/fox2code/foxloader/client/BlockRenderManager.java
@@ -32,7 +32,7 @@ public final class BlockRenderManager {
     private static final int FL_MAX_RENDER_TYPES = 1024;
     private static final int FL_MAX_ID = FL_INITIAL_ID + FL_MAX_RENDER_TYPES - 1;
     private static final BlockRender[] blockRenders = new BlockRender[FL_MAX_RENDER_TYPES];
-    private static int nextID = FL_INITIAL_ID;
+    private static int nextID = 0;
 
     private BlockRenderManager() {}
 
@@ -49,7 +49,7 @@ public final class BlockRenderManager {
                 throw new IllegalStateException("Max number of renders registered!");
             }
             blockRenders[newAssignedID] = blockRender;
-            blockRender.assignedID = newAssignedID;
+            blockRender.assignedID = newAssignedID + FL_INITIAL_ID;
         }
     }
 


### PR DESCRIPTION
Reads to `BlockRenderManager#blockRenders` are shifted by `FL_INITIAL_ID` in `Internal#renderBlockByType` and `Internal#renderItemIn3D`. This means the array needs to start counting from `FL_INITIAL_ID - FL_INITIAL_ID`, i.e. 0

Noticed this porting BuildCraft to your new `BlockRenderer` system.