### PR TITLE
Fix ServerOpenContainer serialisation

### DIFF
--- a/loader/src/main/java/com/fox2code/foxloader/loader/packet/ServerOpenContainer.java
+++ b/loader/src/main/java/com/fox2code/foxloader/loader/packet/ServerOpenContainer.java
@@ -62,11 +62,14 @@ public final class ServerOpenContainer extends FoxPacket {
     @Override
     public void readData(DataInputStream dataInputStream) throws IOException {
         this.containerID = Packet.readString(dataInputStream, 128);
+        this.windowID = dataInputStream.readInt();
         if (dataInputStream.readBoolean()) {
             this.x = dataInputStream.readInt();
             this.y = dataInputStream.readInt();
             this.z = dataInputStream.readInt();
+            this.block = true;
         } else {
+            this.block = false;
             this.x = 0;
             this.y = 0;
             this.z = 0;
@@ -76,6 +79,7 @@ public final class ServerOpenContainer extends FoxPacket {
     @Override
     public void writeData(DataOutputStream dataOutputStream) throws IOException {
         Packet.writeString(this.containerID, dataOutputStream);
+        dataOutputStream.writeInt(this.windowID);
         if (this.block) {
             dataOutputStream.writeBoolean(true);
             dataOutputStream.writeInt(this.x);


### PR DESCRIPTION
`ContainerManager` [presumes](//github.com/Fox2Code/FoxLoader/blob/c0dc06150d74fe63bfa04b4df4bcd47a2e699639/loader/src/main/java/com/fox2code/foxloader/container/ContainerManager.java#L134-L138) these fields are being set when deciding how to open a GUI the server opens.

Without them it will always try to open window ID 0 using `ContainerGuiInvokerReflection#openContainer(int)`